### PR TITLE
[Hotfix] zero transfer in cancel by host

### DIFF
--- a/contracts/DtravelProperty.sol
+++ b/contracts/DtravelProperty.sol
@@ -231,7 +231,7 @@ contract DtravelProperty is Ownable, ReentrancyGuard {
     Any amount that has been paid out to the host or to the treasury through calls to `payout` will have to be refunded manually to the guest.
     */
     function cancelByHost(string memory _bookingId) public nonReentrant onlyHostOrDelegate {
-        Booking storage booking = bookings[getBookingIndex(_bookingId)];
+        Booking memory booking = bookings[getBookingIndex(_bookingId)];
         require(booking.guest != address(0), "Property: Booking does not exist");
         require(
             (booking.status == BookingStatus.InProgress || booking.status == BookingStatus.PartialPayOut) &&
@@ -241,9 +241,8 @@ contract DtravelProperty is Ownable, ReentrancyGuard {
 
         // Refund to the guest
         uint256 guestAmount = booking.balance;
-        
+
         _updateBookingStatus(_bookingId, BookingStatus.CancelledByHost);
-        booking.balance = 0;
 
         _safeTransfer(booking.token, booking.guest, guestAmount);
 


### PR DESCRIPTION
We run into a critical issue on mainnet that causes refund amount locked on Property contract. The main cause is that refund amount is set after execution of `_updateBookingStatus()` function but this function not only change the status of booking order but also reset `bookingAmount` to zero in case of cancellation, so refund amount always become zero in this case.