### PR TITLE
Remove authorized scope from updating payment receiver

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,4 @@
 version: 2.1
-orbs:
-  node: circleci/node@5.0.2
 executors:
   docker-executor:
     docker:

--- a/contracts/Property.sol
+++ b/contracts/Property.sol
@@ -94,24 +94,22 @@ contract Property is
 
     /**
        @notice Update host wallet
-       @dev    Caller must be HOST or AUTHORIZED
-       @param _addr new wallet address
+       @dev    Caller must be HOST or OPERATOR
+       @param _addr new payment receiver address
      */
     function updatePaymentReceiver(address _addr) external {
         address msgSender = _msgSender();
         require(
-            msgSender == host ||
-                msgSender == management.operator() ||
-                authorized[msgSender],
-            "OnlyAuthorized"
+            msgSender == host || msgSender == management.operator(),
+            "OnlyHostOrOperator"
         );
         require(_addr != address(0), "ZeroAddress");
         require(_addr != paymentReceiver, "PaymentReceiverExisted");
 
         paymentReceiver = _addr;
 
-        // also grant authority to this new wallet
-        authorized[_addr] = true;
+        // also transfer host
+        host = _addr;
 
         emit NewPaymentReceiver(_addr);
     }

--- a/contracts/Property.sol
+++ b/contracts/Property.sol
@@ -97,21 +97,18 @@ contract Property is
        @dev    Caller must be HOST or OPERATOR
        @param _addr new payment receiver address
      */
-    function updatePaymentReceiver(address _addr) external {
+    function updateHost(address _addr) external {
         address msgSender = _msgSender();
         require(
             msgSender == host || msgSender == management.operator(),
             "OnlyHostOrOperator"
         );
         require(_addr != address(0), "ZeroAddress");
-        require(_addr != paymentReceiver, "PaymentReceiverExisted");
+        require(_addr != host, "HostExisted");
 
-        paymentReceiver = _addr;
-
-        // also transfer host
         host = _addr;
 
-        emit NewPaymentReceiver(_addr);
+        emit NewHost(_addr);
     }
 
     /**

--- a/contracts/Property.sol
+++ b/contracts/Property.sol
@@ -91,7 +91,7 @@ contract Property is
     /**
        @notice Update host wallet
        @dev    Caller must be HOST or OPERATOR
-       @param _addr new payment receiver address
+       @param _addr new host address
      */
     function updateHost(address _addr) external {
         address msgSender = _msgSender();

--- a/contracts/Property.sol
+++ b/contracts/Property.sol
@@ -35,9 +35,6 @@ contract Property is
     // host of the property
     address public host;
 
-    // address to receive payment
-    address public paymentReceiver;
-
     // address of the property's factory
     address public factory;
 
@@ -61,7 +58,6 @@ contract Property is
 
         propertyId = _propertyId;
         host = _host;
-        paymentReceiver = _host;
         factory = _msgSender();
         management = IManagement(_management);
     }
@@ -142,7 +138,7 @@ contract Property is
         bookingInfo.feeNumerator = management.feeNumerator();
         bookingInfo.guest = sender;
         bookingInfo.paymentToken = _setting.paymentToken;
-        bookingInfo.paymentReceiver = paymentReceiver;
+        bookingInfo.paymentReceiver = host;
         if (_setting.referrer != address(0)) {
             bookingInfo.referrer = _setting.referrer;
             bookingInfo.referralFeeNumerator = management

--- a/contracts/interfaces/IProperty.sol
+++ b/contracts/interfaces/IProperty.sol
@@ -50,7 +50,7 @@ interface IProperty {
 
     function revokeAuthorized(address _addr) external;
 
-    function updatePaymentReceiver(address _addr) external;
+    function updateHost(address _addr) external;
 
     function book(BookingSetting calldata _setting, bytes calldata _signature)
         external;
@@ -65,7 +65,7 @@ interface IProperty {
 
     function totalBookings() external view returns (uint256);
 
-    event NewPaymentReceiver(address indexed paymentReceiver);
+    event NewHost(address indexed host);
 
     event NewBooking(
         address indexed guest,

--- a/contracts/test/PropertyV2.sol
+++ b/contracts/test/PropertyV2.sol
@@ -35,9 +35,6 @@ contract PropertyV2 is
     // host of the property
     address public host;
 
-    // host wallet to receive payment
-    address public paymentReceiver;
-
     // address of the property's factory
     address public factory;
 
@@ -100,10 +97,10 @@ contract PropertyV2 is
        @dev    Caller must be HOST or AUTHORIZED
        @param _newWallet new wallet address
      */
-    function updatePaymentReceiver(address _newWallet) external pure {
+    function updateHost(address _newWallet) external pure {
         _newWallet;
         // solhint-disable-next-line
-        revert("updatePaymentReceiver() upgraded!");
+        revert("updateHost() upgraded!");
     }
 
     /**

--- a/test/Property.ts
+++ b/test/Property.ts
@@ -2756,67 +2756,61 @@ describe("Property test", function () {
     });
   });
 
-  describe("Update payment receiver", async () => {
-    it("should revert when updating payment receiver if caller is NOT HOST/OPERATOR", async () => {
-      const newPaymentReceiver = users[3];
+  describe("Update host", async () => {
+    it("should revert when updating host if caller is NOT HOST/OPERATOR", async () => {
+      const newHost = users[3];
       await expect(
-        property.updatePaymentReceiver(newPaymentReceiver.address)
+        property.updateHost(newHost.address)
       ).revertedWith("OnlyHostOrOperator");
     });
 
-    it("should revert when updating payment receiver if caller is authorized address", async () => {
+    it("should revert when updating host if caller is authorized address", async () => {
       const authorizedUser = users[11];
-      const newPaymentReceiver = users[3];
+      const newHost = users[3];
       await expect(
         property
           .connect(authorizedUser)
-          .updatePaymentReceiver(newPaymentReceiver.address)
+          .updateHost(newHost.address)
       ).revertedWith("OnlyHostOrOperator");
     });
 
-    it("should revert when updating payment receiver to zero address", async () => {
+    it("should revert when updating host to zero address", async () => {
       await expect(
-        property.connect(host).updatePaymentReceiver(constants.AddressZero)
+        property.connect(host).updateHost(constants.AddressZero)
       ).revertedWith("ZeroAddress");
     });
 
-    it("should allow host to update payment receiver", async () => {
-      const newPaymentReceiver = users[10];
+    it("should allow host to update host", async () => {
+      const newHost = users[10];
       await expect(
-        property.connect(host).updatePaymentReceiver(newPaymentReceiver.address)
+        property.connect(host).updateHost(newHost.address)
       )
-        .emit(property, "NewPaymentReceiver")
-        .withArgs(newPaymentReceiver.address);
+        .emit(property, "NewHost")
+        .withArgs(newHost.address);
 
-      const paymentReceiver = await property.paymentReceiver();
-      expect(paymentReceiver).deep.equal(newPaymentReceiver.address);
-
-      const newHost = await property.host();
-      expect(newHost).deep.equal(newPaymentReceiver.address);
+      const newHostResult = await property.host();
+      expect(newHostResult).deep.equal(newHost.address);
     });
 
-    it("should allow operator to update payment receiver", async () => {
-      const newPaymentReceiver = users[11];
+    it("should allow operator to update host", async () => {
+      const newHost = users[11];
       await expect(
         property
           .connect(operator)
-          .updatePaymentReceiver(newPaymentReceiver.address)
+          .updateHost(newHost.address)
       )
-        .emit(property, "NewPaymentReceiver")
-        .withArgs(newPaymentReceiver.address);
+        .emit(property, "NewHost")
+        .withArgs(newHost.address);
 
-      const paymentReceiver = await property.paymentReceiver();
-      expect(paymentReceiver).deep.equal(newPaymentReceiver.address);
-
-      const newHost = await property.host();
-      expect(newHost).deep.equal(newPaymentReceiver.address);
+      const newHostResult = await property.host();
+      expect(newHostResult).deep.equal(newHost.address);
     });
 
-    it("should revert when updating payment receiver that has already set up", async () => {
+    it("should revert when updating host that has already set up", async () => {
       const newHost = users[11];
       await expect(
-        property.connect(newHost).updatePaymentReceiver(newHost.address)
-      ).revertedWith("PaymentReceiverExisted");
+        property.connect(newHost).updateHost(newHost.address)
+      ).revertedWith("HostExisted");
     });
 
     it("should transfer to new host wallet when paying out after host updates wallet", async () => {
@@ -2865,13 +2859,12 @@ describe("Property test", function () {
 
       // host update new payment receiver
       const currentHost = users[11];
-      const newPaymentReceiver = host;
+      const newHost = host;
       await property
         .connect(currentHost)
-        .updatePaymentReceiver(newPaymentReceiver.address);
+        .updateHost(newHost.address);
 
       const oldHost = currentHost;
-      const newHost = newPaymentReceiver;
 
       // create a new booking after updating payment receiver
       const guest2 = users[1];
@@ -2972,7 +2965,7 @@ describe("Property test", function () {
         oldHostBalanceBefore.add(oldHostRevenue)
       );
 
-      const newHostBalance = await trvl.balanceOf(newPaymentReceiver.address);
+      const newHostBalance = await trvl.balanceOf(newHost.address);
       expect(newHostBalance).deep.equal(
         newHostBalanceBefore.add(newHostRevenue)
       );

--- a/test/Property.ts
+++ b/test/Property.ts
@@ -2759,18 +2759,16 @@ describe("Property test", function () {
   describe("Update host", async () => {
     it("should revert when updating host if caller is NOT HOST/OPERATOR", async () => {
       const newHost = users[3];
-      await expect(
-        property.updateHost(newHost.address)
-      ).revertedWith("OnlyHostOrOperator");
+      await expect(property.updateHost(newHost.address)).revertedWith(
+        "OnlyHostOrOperator"
+      );
     });
 
     it("should revert when updating host if caller is authorized address", async () => {
       const authorizedUser = users[11];
       const newHost = users[3];
       await expect(
-        property
-          .connect(authorizedUser)
-          .updateHost(newHost.address)
+        property.connect(authorizedUser).updateHost(newHost.address)
       ).revertedWith("OnlyHostOrOperator");
     });
 
@@ -2782,9 +2780,7 @@ describe("Property test", function () {
 
     it("should allow host to update host", async () => {
       const newHost = users[10];
-      await expect(
-        property.connect(host).updateHost(newHost.address)
-      )
+      await expect(property.connect(host).updateHost(newHost.address))
         .emit(property, "NewHost")
         .withArgs(newHost.address);
 
@@ -2794,11 +2790,7 @@ describe("Property test", function () {
 
     it("should allow operator to update host", async () => {
       const newHost = users[11];
-      await expect(
-        property
-          .connect(operator)
-          .updateHost(newHost.address)
-      )
+      await expect(property.connect(operator).updateHost(newHost.address))
         .emit(property, "NewHost")
         .withArgs(newHost.address);
 
@@ -2860,9 +2852,7 @@ describe("Property test", function () {
       // host update new payment receiver
       const currentHost = users[11];
       const newHost = host;
-      await property
-        .connect(currentHost)
-        .updateHost(newHost.address);
+      await property.connect(currentHost).updateHost(newHost.address);
 
       const oldHost = currentHost;
 

--- a/test/Property.ts
+++ b/test/Property.ts
@@ -2849,14 +2849,14 @@ describe("Property test", function () {
         "NewBooking"
       );
 
-      // host update new payment receiver
+      // update new host
       const currentHost = users[11];
       const newHost = host;
       await property.connect(currentHost).updateHost(newHost.address);
 
       const oldHost = currentHost;
 
-      // create a new booking after updating payment receiver
+      // create a new booking after updating host
       const guest2 = users[1];
       const setting2 = {
         bookingId: 11,

--- a/test/UpgradeableProperty.ts
+++ b/test/UpgradeableProperty.ts
@@ -149,13 +149,13 @@ describe("Property test", function () {
     });
 
     it("should upgrade updateHost()", async () => {
-      await expect(
-        upgradedProperty1.updateHost(users[3].address)
-      ).revertedWith("updateHost() upgraded!");
+      await expect(upgradedProperty1.updateHost(users[3].address)).revertedWith(
+        "updateHost() upgraded!"
+      );
 
-      await expect(
-        upgradedProperty2.updateHost(users[3].address)
-      ).revertedWith("updateHost() upgraded!");
+      await expect(upgradedProperty2.updateHost(users[3].address)).revertedWith(
+        "updateHost() upgraded!"
+      );
     });
 
     it("should upgrade book()", async () => {

--- a/test/UpgradeableProperty.ts
+++ b/test/UpgradeableProperty.ts
@@ -148,14 +148,14 @@ describe("Property test", function () {
       ).revertedWith("revokeAuthorized() upgraded!");
     });
 
-    it("should upgrade updatePaymentReceiver()", async () => {
+    it("should upgrade updateHost()", async () => {
       await expect(
-        upgradedProperty1.updatePaymentReceiver(users[3].address)
-      ).revertedWith("updatePaymentReceiver() upgraded!");
+        upgradedProperty1.updateHost(users[3].address)
+      ).revertedWith("updateHost() upgraded!");
 
       await expect(
-        upgradedProperty2.updatePaymentReceiver(users[3].address)
-      ).revertedWith("updatePaymentReceiver() upgraded!");
+        upgradedProperty2.updateHost(users[3].address)
+      ).revertedWith("updateHost() upgraded!");
     });
 
     it("should upgrade book()", async () => {


### PR DESCRIPTION
- Do not allow authorized address to update payment receiver
- Transfer host to new payment receiver address 