### PR TITLE
Update payment receiver & enable operator to be authorized address by default

### DIFF
--- a/contracts/Property.sol
+++ b/contracts/Property.sol
@@ -94,10 +94,8 @@ contract Property is IProperty, OwnableUpgradeable, ReentrancyGuardUpgradeable {
         require(_addr != host, "HostExisted");
 
         host = _addr;
-        paymentReceiver = _addr;
 
         emit NewHost(_addr);
-        emit NewPaymentReceiver(_addr);
     }
 
     /**
@@ -108,7 +106,7 @@ contract Property is IProperty, OwnableUpgradeable, ReentrancyGuardUpgradeable {
     function updatePaymentReceiver(address _addr) external {
         address msgSender = _msgSender();
         require(
-            msgSender == host || authorized[msgSender],
+            msgSender == host || authorized[msgSender], 
             "OnlyHostOrDelegator"
         );
         require(_addr != address(0), "ZeroAddress");

--- a/contracts/Property.sol
+++ b/contracts/Property.sol
@@ -51,6 +51,7 @@ contract Property is IProperty, OwnableUpgradeable, ReentrancyGuardUpgradeable {
         paymentReceiver = _host;
         factory = _msgSender();
         management = IManagement(_management);
+        authorized[management.operator()] = true;
     }
 
     /**
@@ -85,7 +86,11 @@ contract Property is IProperty, OwnableUpgradeable, ReentrancyGuardUpgradeable {
        @param _addr new host address
      */
     function updateHost(address _addr) external {
-        require(_msgSender() == management.operator(), "OnlyOperator");
+        address msgSender = _msgSender();
+        require(
+            msgSender == host || msgSender == management.operator(),
+            "OnlyHostOrOperator"
+        );
         require(_addr != address(0), "ZeroAddress");
         require(_addr != host, "HostExisted");
 

--- a/contracts/Property.sol
+++ b/contracts/Property.sol
@@ -101,14 +101,14 @@ contract Property is IProperty, OwnableUpgradeable, ReentrancyGuardUpgradeable {
 
     /**
         @notice Update payment receiver wallet
-        @dev    Caller must be HOST or DELEGATOR
+        @dev    Caller must be HOST or AUTHORIZED ADDRESS
         @param _addr new payment receiver address
      */
     function updatePaymentReceiver(address _addr) external {
         address msgSender = _msgSender();
         require(
             msgSender == host || authorized[msgSender],
-            "OnlyHostOrDelegator"
+            "OnlyHostOrAuthorizedAddress"
         );
         require(_addr != address(0), "ZeroAddress");
         require(_addr != paymentReceiver, "PaymentReceiverExisted");

--- a/contracts/Property.sol
+++ b/contracts/Property.sol
@@ -106,7 +106,7 @@ contract Property is IProperty, OwnableUpgradeable, ReentrancyGuardUpgradeable {
     function updatePaymentReceiver(address _addr) external {
         address msgSender = _msgSender();
         require(
-            msgSender == host || authorized[msgSender], 
+            msgSender == host || authorized[msgSender],
             "OnlyHostOrDelegator"
         );
         require(_addr != address(0), "ZeroAddress");

--- a/contracts/Property.sol
+++ b/contracts/Property.sol
@@ -23,6 +23,9 @@ contract Property is IProperty, OwnableUpgradeable, ReentrancyGuardUpgradeable {
     // host of the property
     address public host;
 
+    // address of booking payment recipient
+    address public paymentReceiver;
+
     // address of the property's factory
     address public factory;
 
@@ -45,6 +48,7 @@ contract Property is IProperty, OwnableUpgradeable, ReentrancyGuardUpgradeable {
 
         propertyId = _propertyId;
         host = _host;
+        paymentReceiver = _host;
         factory = _msgSender();
         management = IManagement(_management);
     }
@@ -90,8 +94,26 @@ contract Property is IProperty, OwnableUpgradeable, ReentrancyGuardUpgradeable {
         require(_addr != host, "HostExisted");
 
         host = _addr;
+        paymentReceiver = _addr;
 
         emit NewHost(_addr);
+        emit NewPaymentReceiver(_addr);  
+    }
+
+    /**
+        @notice Update payment receiver wallet
+        @dev    Caller must be HOST or DELEGATOR
+        @param _addr new payment receiver address
+     */
+    function updatePaymentReceiver(address _addr) external {
+        address msgSender = _msgSender();
+        require(msgSender == host || authorized[msgSender], "OnlyHostOrDelegator");
+        require(_addr != address(0), "ZeroAddress");
+        require(_addr != paymentReceiver, "PaymentReceiverExisted");
+
+        paymentReceiver = _addr;
+
+        emit NewPaymentReceiver(_addr);
     }
 
     /**
@@ -125,7 +147,7 @@ contract Property is IProperty, OwnableUpgradeable, ReentrancyGuardUpgradeable {
         bookingInfo.feeNumerator = management.feeNumerator();
         bookingInfo.guest = sender;
         bookingInfo.paymentToken = _setting.paymentToken;
-        bookingInfo.paymentReceiver = host;
+        bookingInfo.paymentReceiver = paymentReceiver;
         if (_setting.referrer != address(0)) {
             bookingInfo.referrer = _setting.referrer;
             bookingInfo.referralFeeNumerator = management

--- a/contracts/Property.sol
+++ b/contracts/Property.sol
@@ -97,7 +97,7 @@ contract Property is IProperty, OwnableUpgradeable, ReentrancyGuardUpgradeable {
         paymentReceiver = _addr;
 
         emit NewHost(_addr);
-        emit NewPaymentReceiver(_addr);  
+        emit NewPaymentReceiver(_addr);
     }
 
     /**
@@ -107,7 +107,10 @@ contract Property is IProperty, OwnableUpgradeable, ReentrancyGuardUpgradeable {
      */
     function updatePaymentReceiver(address _addr) external {
         address msgSender = _msgSender();
-        require(msgSender == host || authorized[msgSender], "OnlyHostOrDelegator");
+        require(
+            msgSender == host || authorized[msgSender],
+            "OnlyHostOrDelegator"
+        );
         require(_addr != address(0), "ZeroAddress");
         require(_addr != paymentReceiver, "PaymentReceiverExisted");
 

--- a/contracts/interfaces/IProperty.sol
+++ b/contracts/interfaces/IProperty.sol
@@ -54,6 +54,8 @@ interface IProperty {
 
     function updateHost(address _addr) external;
 
+    function updatePaymentReceiver(address _addr) external;
+
     function book(BookingSetting calldata _setting, bytes calldata _signature)
         external;
 
@@ -68,6 +70,8 @@ interface IProperty {
     function totalBookings() external view returns (uint256);
 
     event NewHost(address indexed host);
+
+    event NewPaymentReceiver(address indexed paymentReceiver);
 
     event NewBooking(
         address indexed guest,

--- a/contracts/test/PropertyV2.sol
+++ b/contracts/test/PropertyV2.sol
@@ -24,6 +24,9 @@ contract PropertyV2 is
     // host of the property
     address public host;
 
+    // address of booking payment recipient
+    address public paymentReceiver;
+
     // address of the property's factory
     address public factory;
 
@@ -56,6 +59,7 @@ contract PropertyV2 is
 
         propertyId = _propertyId;
         host = _host;
+        paymentReceiver = _host;
         factory = _msgSender();
         management = IManagement(_management);
     }
@@ -89,6 +93,17 @@ contract PropertyV2 is
         _newWallet;
         // solhint-disable-next-line
         revert("updateHost() upgraded!");
+    }
+
+    /**
+        @notice Update payment receiver wallet
+        @dev    Caller must be HOST or DELEGATOR
+        @param _addr new payment receiver address
+     */
+    function updatePaymentReceiver(address _addr) external pure {
+        _addr;
+        // solhint-disable-next-line
+        revert("updatePaymentReceiver() upgraded!");
     }
 
     /**

--- a/test/Property.ts
+++ b/test/Property.ts
@@ -2958,14 +2958,20 @@ describe("Property test", function () {
     it("should revert when updating payment receiver to zero address", async () => {
       const currentHost = users[11];
       await expect(
-        property.connect(currentHost).updatePaymentReceiver(constants.AddressZero)
+        property
+          .connect(currentHost)
+          .updatePaymentReceiver(constants.AddressZero)
       ).revertedWith("ZeroAddress");
     });
 
     it("should allow host to update payment receiver", async () => {
       const currentHost = users[11];
       const newPaymentReceiver = users[12];
-      await expect(property.connect(currentHost).updatePaymentReceiver(newPaymentReceiver.address))
+      await expect(
+        property
+          .connect(currentHost)
+          .updatePaymentReceiver(newPaymentReceiver.address)
+      )
         .emit(property, "NewPaymentReceiver")
         .withArgs(newPaymentReceiver.address);
 
@@ -2978,7 +2984,11 @@ describe("Property test", function () {
       const newPaymentReceiver = users[13];
       const delegator = users[1];
       await property.connect(currentHost).grantAuthorized(delegator.address);
-      await expect(property.connect(delegator).updatePaymentReceiver(newPaymentReceiver.address))
+      await expect(
+        property
+          .connect(delegator)
+          .updatePaymentReceiver(newPaymentReceiver.address)
+      )
         .emit(property, "NewPaymentReceiver")
         .withArgs(newPaymentReceiver.address);
 
@@ -2990,7 +3000,9 @@ describe("Property test", function () {
       const currentHost = users[11];
       const newPaymentReceiver = users[13];
       await expect(
-        property.connect(currentHost).updatePaymentReceiver(newPaymentReceiver.address)
+        property
+          .connect(currentHost)
+          .updatePaymentReceiver(newPaymentReceiver.address)
       ).revertedWith("PaymentReceiverExisted");
     });
 
@@ -3033,7 +3045,9 @@ describe("Property test", function () {
       const currentPaymentReceiver = users[13];
       const newPaymentReceiver = users[12];
 
-      await property.connect(currentHost).updatePaymentReceiver(newPaymentReceiver.address);
+      await property
+        .connect(currentHost)
+        .updatePaymentReceiver(newPaymentReceiver.address);
 
       const oldPaymentReceiver = currentPaymentReceiver;
 
@@ -3070,8 +3084,12 @@ describe("Property test", function () {
       );
 
       // get balances of old and new payment receiver wallet before guest making payouts
-      const oldPaymentReceiverBalanceBefore = await trvl.balanceOf(oldPaymentReceiver.address);
-      const newPaymentReceiverBalanceBefore = await trvl.balanceOf(newPaymentReceiver.address);
+      const oldPaymentReceiverBalanceBefore = await trvl.balanceOf(
+        oldPaymentReceiver.address
+      );
+      const newPaymentReceiverBalanceBefore = await trvl.balanceOf(
+        newPaymentReceiver.address
+      );
 
       // calculate fees and related amounts for booking 1 (id = 10)
       const booking1Info = await property.getBookingById(setting1.bookingId);
@@ -3121,12 +3139,16 @@ describe("Property test", function () {
       await decreaseTime(4 * days + 1);
 
       // check balances old and new payment reiver
-      const oldPaymentReceiverBalance = await trvl.balanceOf(oldPaymentReceiver.address);
+      const oldPaymentReceiverBalance = await trvl.balanceOf(
+        oldPaymentReceiver.address
+      );
       expect(oldPaymentReceiverBalance).deep.equal(
         oldPaymentReceiverBalanceBefore.add(oldPaymentReceiverRevenue)
       );
 
-      const newPaymentReceiverBalance = await trvl.balanceOf(newPaymentReceiver.address);
+      const newPaymentReceiverBalance = await trvl.balanceOf(
+        newPaymentReceiver.address
+      );
       expect(newPaymentReceiverBalance).deep.equal(
         newPaymentReceiverBalanceBefore.add(newPaymentReceiverRevenue)
       );

--- a/test/Property.ts
+++ b/test/Property.ts
@@ -3023,7 +3023,9 @@ describe("Property test", function () {
       const currentHost = users[11];
       const newPaymentReceiver = users[13];
       const authorizedUser = users[1];
-      await property.connect(currentHost).grantAuthorized(authorizedUser.address);
+      await property
+        .connect(currentHost)
+        .grantAuthorized(authorizedUser.address);
       await expect(
         property
           .connect(authorizedUser)

--- a/test/Property.ts
+++ b/test/Property.ts
@@ -2948,11 +2948,11 @@ describe("Property test", function () {
   });
 
   describe("Update payment receiver", async () => {
-    it("should revert when updating payment receiver if caller is NOT HOST/DELEGATOR", async () => {
+    it("should revert when updating payment receiver if caller is NOT HOST/AUTHORIZED ADDRESS", async () => {
       const newPaymentReceiver = users[3];
       await expect(
         property.updatePaymentReceiver(newPaymentReceiver.address)
-      ).revertedWith("OnlyHostOrDelegator");
+      ).revertedWith("OnlyHostOrAuthorizedAddress");
     });
 
     it("should revert when updating payment receiver to zero address", async () => {
@@ -3004,7 +3004,7 @@ describe("Property test", function () {
         property
           .connect(newOperator)
           .updatePaymentReceiver(newPaymentReceiver.address)
-      ).revertedWith("OnlyHostOrDelegator");
+      ).revertedWith("OnlyHostOrAuthorizedAddress");
 
       await property.connect(currentHost).grantAuthorized(newOperator.address);
       await expect(
@@ -3019,14 +3019,14 @@ describe("Property test", function () {
       expect(newPaymentReceiverResult).deep.equal(newPaymentReceiver.address);
     });
 
-    it("should allow delegator to update payment receiver", async () => {
+    it("should allow authorized address to update payment receiver", async () => {
       const currentHost = users[11];
       const newPaymentReceiver = users[13];
-      const delegator = users[1];
-      await property.connect(currentHost).grantAuthorized(delegator.address);
+      const authorizedUser = users[1];
+      await property.connect(currentHost).grantAuthorized(authorizedUser.address);
       await expect(
         property
-          .connect(delegator)
+          .connect(authorizedUser)
           .updatePaymentReceiver(newPaymentReceiver.address)
       )
         .emit(property, "NewPaymentReceiver")

--- a/test/UpgradeableProperty.ts
+++ b/test/UpgradeableProperty.ts
@@ -159,13 +159,13 @@ describe("Upgradeable property test", function () {
     });
 
     it("should upgrade updatePaymentReceiver()", async () => {
-      await expect(upgradedProperty1.updatePaymentReceiver(users[4].address)).revertedWith(
-        "updatePaymentReceiver() upgraded!"
-      );
+      await expect(
+        upgradedProperty1.updatePaymentReceiver(users[4].address)
+      ).revertedWith("updatePaymentReceiver() upgraded!");
 
-      await expect(upgradedProperty2.updatePaymentReceiver(users[4].address)).revertedWith(
-        "updatePaymentReceiver() upgraded!"
-      );
+      await expect(
+        upgradedProperty2.updatePaymentReceiver(users[4].address)
+      ).revertedWith("updatePaymentReceiver() upgraded!");
     });
 
     it("should upgrade book()", async () => {

--- a/test/UpgradeableProperty.ts
+++ b/test/UpgradeableProperty.ts
@@ -158,6 +158,16 @@ describe("Upgradeable property test", function () {
       );
     });
 
+    it("should upgrade updatePaymentReceiver()", async () => {
+      await expect(upgradedProperty1.updatePaymentReceiver(users[4].address)).revertedWith(
+        "updatePaymentReceiver() upgraded!"
+      );
+
+      await expect(upgradedProperty2.updatePaymentReceiver(users[4].address)).revertedWith(
+        "updatePaymentReceiver() upgraded!"
+      );
+    });
+
     it("should upgrade book()", async () => {
       const guest = users[1];
       const now = (await ethers.provider.getBlock("latest")).timestamp;


### PR DESCRIPTION
- Allow host or delegator to update payment receipt address
- Enable operator to be authorized address by default (setup in constructor of Property contract)